### PR TITLE
Integrate resqui pipeline

### DIFF
--- a/.github/workflows/resqui.yml
+++ b/.github/workflows/resqui.yml
@@ -2,7 +2,7 @@ name: Run resqui
 
 on:
   push:
-  pull_request:
+  workflow_dispatch:
 
 jobs:
   resqui:

--- a/.github/workflows/resqui.yml
+++ b/.github/workflows/resqui.yml
@@ -1,0 +1,23 @@
+name: Run resqui
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  resqui:
+    runs-on: self-hosted
+    environment: resqui
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Run resqui
+        uses: thodkatz/QualityPipelines@main
+        with:
+          config: configurations/basic.json
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          dashverse_token: ${{ secrets.DASHVERSE_TOKEN }}

--- a/.github/workflows/resqui.yml
+++ b/.github/workflows/resqui.yml
@@ -7,7 +7,6 @@ on:
 jobs:
   resqui:
     runs-on: self-hosted
-    environment: resqui
 
     steps:
       - name: Checkout repository

--- a/configurations/basic.json
+++ b/configurations/basic.json
@@ -1,0 +1,18 @@
+{
+  "indicators": [
+    { "name": "archived_in_software_heritage", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/archived_in_software_heritage" },
+    { "name": "descriptive_metadata", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/descriptive_metadata" },
+    { "name": "software_has_citation", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/software_has_citation" },
+    { "name": "has_ci_tests", "plugin": "OpenSSFScorecard", "@id": "https://w3id.org/everse/i/indicators/has_ci-tests" },
+    { "name": "software_has_license", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/software_has_license" },
+    { "name": "has_published_package", "plugin": "OpenSSFScorecard", "@id": "https://w3id.org/everse/i/indicators/has_published_package" },
+    { "name": "has_releases", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/has_releases" },
+    { "name": "repository_workflows", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/repository_workflows" },
+    { "name": "requirements_specified", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/requirements_specified" },
+    { "name": "persistent_and_unique_identifier", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/persistent_and_unique_identifier" },
+    { "name": "software_has_documentation", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/software_has_documentation" },
+    { "name": "software_has_tests", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/software_has_tests" },
+    { "name": "version_control_use", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/version_control_use" },
+    { "name": "versioning_standards_use", "plugin": "RSFC", "@id": "https://w3id.org/everse/i/indicators/versioning_standards_use" }
+  ]
+}


### PR DESCRIPTION
This is an attempt to run [resqui](https://github.com/EVERSE-ResearchSoftware/QualityPipelines) via github actions and to publish the summary report to a self hosted [DashVERSE](https://github.com/thodkatz/DashVERSE) instanced deployed at INAB-CERTH.

I have already tested the integration with this [project](https://github.com/thodkatz/everse-resqui-demo/tree/main). With this PR I am attempting to test the integration at the organization level.

For security reasons, since the action is running locally, it needs to be approved for external (not within the org) users.

We should be able to view the dashboard at http://160.40.71.177:8083/ within the LAN.

Note:
A secret for the dashverse token is saved at the org level. PRs from forks can't read these secrets, so publishing results won't work. The secret can be read only if the branch is on the base, so it will work at merge point. Otherwise PRs from base branches will work as well.